### PR TITLE
fix: improve CI workflows and fix Cypress execution issues

### DIFF
--- a/.github/workflows/gcp-cypress.yml
+++ b/.github/workflows/gcp-cypress.yml
@@ -27,10 +27,6 @@ jobs:
   trigger-gcp-tests:
     name: Trigger GCP Cloud Build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2]  # Using 2 containers for parallelization
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,14 +47,15 @@ jobs:
         run: |
           BUILD_ID=$(gcloud builds submit --config=cloudbuild.yaml \
             --no-source \
-            --substitutions=_ENV=${{ github.event.inputs.environment }},_SPECS=${{ github.event.inputs.specs }},_CONTAINER_IDX=${{ matrix.containers }},_TOTAL_CONTAINERS=${{ strategy.job-total }},_REPO_URL="${{ github.server_url }}/${{ github.repository }}.git",_BRANCH="${{ github.ref_name }}",_CYPRESS_RECORD_KEY="${{ secrets.CYPRESS_RECORD_KEY }}",_TAGS="${{ github.event.inputs.tags }}",_PERCY_TOKEN="${{ secrets.PERCY_TOKEN }}",_PROJECT_TOKEN="${{ secrets.PROJECT_TOKEN }}" \
+            --substitutions=_ENV=${{ github.event.inputs.environment }},_SPECS=${{ github.event.inputs.specs }},_TOTAL_CONTAINERS=2,_REPO_URL="${{ github.server_url }}/${{ github.repository }}.git",_BRANCH="${{ github.ref_name }}",_CYPRESS_RECORD_KEY="${{ secrets.CYPRESS_RECORD_KEY }}",_TAGS="${{ github.event.inputs.tags }}",_PERCY_TOKEN="${{ secrets.PERCY_TOKEN }}",_PROJECT_TOKEN="${{ secrets.PROJECT_TOKEN }}" \
             --async --format='value(id)')
           echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
           echo "Triggered Cloud Build with ID: $BUILD_ID"
 
       - name: Wait for Cloud Build to complete
         run: |
-          gcloud beta builds log --stream ${{ steps.cloud-build.outputs.build_id }}
+          gcloud components install beta --quiet
+          gcloud beta builds log --quiet --stream ${{ steps.cloud-build.outputs.build_id }}
 
       - name: Download test results from GCS
         id: download-gcs
@@ -72,7 +69,7 @@ jobs:
       - name: Save results folder
         uses: actions/upload-artifact@v4
         with:
-          name: cypress-results-${{ matrix.containers }}
+          name: cypress-results
           path: cypress/results/json
 
   post-tests-results:
@@ -107,6 +104,7 @@ jobs:
       - name: Prepare results directory
         run: |
           mkdir -p cypress/results/json
+          # Copy all JSON files from all container directories to the main json directory
           find downloaded-artifacts -name "*.json" -exec cp {} cypress/results/json/ \; || echo "No JSON files found"
           echo "Contents of cypress/results/json:"
           ls -la cypress/results/json || echo "Directory is empty"

--- a/.github/workflows/gha-cypress.yml
+++ b/.github/workflows/gha-cypress.yml
@@ -98,14 +98,14 @@ jobs:
 
       - name: Create results directory if it doesn't exist
         if: ${{ always() }}
-        run: mkdir -p cypress/results/json
+        run: mkdir -p cypress/results/json/container-${{ matrix.containers }}
 
       - name: Save results folder
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: cypress-results-${{ matrix.containers }}
-          path: cypress/results/json
+          path: cypress/results/json/container-${{ matrix.containers }}
 
   post-tests-results:
     runs-on: ubuntu-latest
@@ -139,6 +139,7 @@ jobs:
      - name: Prepare results directory
        run: |
          mkdir -p cypress/results/json
+         # Copy all JSON files from all container directories to the main json directory
          find downloaded-artifacts -name "*.json" -exec cp {} cypress/results/json/ \; || echo "No JSON files found"
          echo "Contents of cypress/results/json:"
          ls -la cypress/results/json || echo "Directory is empty"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,10 +19,45 @@ steps:
   - name: 'debian:stable-slim'
     args: ['chmod', '+x', 'run-cypress.sh']
 
-  # Run Cypress tests
+  # Install Cypress once
   - name: 'cypress/included:14.3.0'
-    entrypoint: './run-cypress.sh'
-    args: ['${_ENV}', '${_SPECS}', '${_CONTAINER_IDX}', '${BUILD_ID}', '${_CYPRESS_RECORD_KEY}', '${_TAGS}']
+    id: 'install-cypress'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        cypress install
+        cypress verify
+        echo "Cypress binary installed successfully"
+
+  # Run parallel tests dynamically
+  - name: 'cypress/included:14.3.0'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Create an array to store process IDs
+        declare -a PIDS
+        FAILED=0
+        
+        # Run tests in parallel
+        for i in $(seq 1 ${_TOTAL_CONTAINERS}); do
+          echo "Starting container $i of ${_TOTAL_CONTAINERS}"
+          ./run-cypress.sh "${_ENV}" "${_SPECS}" "$i" "${BUILD_ID}" "${_CYPRESS_RECORD_KEY}" "${_TAGS}" &
+          PIDS[$i]=$!
+        done
+        
+        # Wait for all processes to complete
+        for i in $(seq 1 ${_TOTAL_CONTAINERS}); do
+          if wait ${PIDS[$i]}; then
+            echo "Container $i completed successfully"
+          else
+            echo "Container $i failed with exit code $?"
+            FAILED=1
+          fi
+        done
+        
+        exit ${FAILED}
     env:
       - 'CI_PLATFORM=gcp'
       - 'CI_SERVICE=cloud-build'

--- a/run-cypress.sh
+++ b/run-cypress.sh
@@ -80,6 +80,6 @@ ENV=$ENV npx cypress run \
   --group "$CI_PLATFORM-parallel-group" \
   --tag "$CI_PLATFORM,$CI_SERVICE,container-$CONTAINER_IDX"
 
-# Create results directory with proper structure for JSON reports
-mkdir -p cypress/results/json
-echo "Created cypress/results/json directory for test reports"
+# Create container-specific results directory
+mkdir -p cypress/results/json/container-$CONTAINER_IDX
+echo "Created cypress/results/json/container-$CONTAINER_IDX directory for test reports"


### PR DESCRIPTION
- Fix gcloud beta builds log command by adding --quiet flag
- Implement dynamic parallelization in Cloud Build to install Cypress once
- Create container-specific directories for test results
- Ensure proper merging of test results for report generation

Start New Task